### PR TITLE
add custom alert script support

### DIFF
--- a/chkboot-bootcheck
+++ b/chkboot-bootcheck
@@ -18,3 +18,9 @@ if [ ! $(echo "${CHKBOOT_STYLES}" | grep -c "issue") = 0 ]; then
     CHKBOOT_CHECK=$(chkboot-check)
     if [ "$?" = 1 ]; then echo "${CHKBOOT_CHECK}" >> /etc/issue; fi
 fi
+
+# run the alert script, if executable
+if [ -x "${CHKBOOT_ALERT_SCRIPT}" ]; then
+    CHKBOOT_CHECK=$(chkboot-check)
+    if [ "$?" = 1 ]; then "${CHKBOOT_ALERT_SCRIPT}"; fi
+fi

--- a/chkboot.conf
+++ b/chkboot.conf
@@ -25,5 +25,8 @@ CHANGES_LOG="boot-differences-log"
 # profile: executes as a user's terminal session begins
 CHKBOOT_STYLES="issue,profile"
 
+#Alert script to run, leave as empty to disable
+CHKBOOT_ALERT_SCRIPT=""
+
 #Highlight colour
 HIGHLIGHT_COLOUR="31"


### PR DESCRIPTION
Users can now run a custom alert script upon hash check failure. The alert script can be used to take down network interfaces immediately, unmount all encrypted volumes, etc.
